### PR TITLE
simplifying core namespace fns and clean code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ pom.xml.asc
 .hgignore
 .hg/
 .idea/
+.history/
+.calva/
+.idea/
+.lsp/
+.clj-kondo/

--- a/src/inspector_gadget/core.clj
+++ b/src/inspector_gadget/core.clj
@@ -1,9 +1,9 @@
 (ns inspector-gadget.core
-  (:require [clojure.pprint :as pprint]
-            [inspector-gadget.diplomat.file :as file]
-            [inspector-gadget.logic.parser :as parser]
+  (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.edn :as edn]))
+            [clojure.pprint :as pprint]
+            [inspector-gadget.diplomat.file :as file]
+            [inspector-gadget.logic.parser :as parser]))
 
 (defn- mapv-filter
   ([f coll]


### PR DESCRIPTION
- Adding some Calva related files to `.gitignore`
- `(reduce concat (map f coll))` **==** `(mapcat f coll)`
-  `map` and `filter identity` are being used three times in different fns. Moved to `mapv-filter` generic fn (we can move it to a `misc` or similar namespace later)
- Clean code and small fixes
- Lint fix